### PR TITLE
feat: add laminas-dependency-plugin v2 constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+### Added
+- Allow usage of laminas-dependency-plugin v2
+
 ## [3.0.0]
 ### Changed
 - Migrated Zend to Laminas

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "goaop/framework": "^1.0|^2.0",
         "laminas/laminas-modulemanager": "^2.0",
-        "laminas/laminas-dependency-plugin": "^1.0"
+        "laminas/laminas-dependency-plugin": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 | ^6.0",


### PR DESCRIPTION
add laminas-dependency-plugin v2 constraint in order to allow usage with composer v2